### PR TITLE
Install into /usr/local by default

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -4,7 +4,7 @@ VERSION = instantOS-Alpha
 # Customize below to fit your system
 
 # paths
-PREFIX = /usr
+PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
 X11INC = /usr/X11R6/include


### PR DESCRIPTION
`/usr/local` is generally used for packages not managed by a package manager, so I think it would make sense to install instantWM there by default for people building from this git repo. Let me know what you think!