### PR TITLE
Fix memory leaks in drw

### DIFF
--- a/drw.c
+++ b/drw.c
@@ -96,6 +96,7 @@ drw_free(Drw *drw)
 {
 	XFreePixmap(drw->dpy, drw->drawable);
 	XFreeGC(drw->dpy, drw->gc);
+	drw_fontset_free(drw->fonts);
 	free(drw);
 }
 
@@ -285,7 +286,7 @@ drw_text(Drw *drw, int x, int y, unsigned int w, unsigned int h, unsigned int lp
 		w = ~w;
 	} else {
 		XSetForeground(drw->dpy, drw->gc, drw->scheme[invert ? ColFg : ColBg].pixel);
-		
+
 		if (rounded) {
 			XFillRectangle(drw->dpy, drw->drawable, drw->gc, x, y, w, h - rounded);
 			XSetForeground(drw->dpy, drw->gc, drw->scheme[ColFloat].pixel);


### PR DESCRIPTION
The function drw_fontset_free in drw.c was never called.
(upstream: f04cac6d by Alex Flieri)