### PR TITLE
fix zoom crash

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -5591,6 +5591,9 @@ void
 zoom(const Arg *arg)
 {
 	Client *c = selmon->sel;
+	if(!c)
+		return;
+
 	XRaiseWindow(dpy, c->win);
 	if (!selmon->lt[selmon->sellt]->arrange
 	|| (selmon->sel && selmon->sel->isfloating))


### PR DESCRIPTION
Previously, when on an empty workspace, pressing Mod + Enter (calling `zoom()`) would crash instantWM, because the `c` pointer was not NULL checked before being used.