### PR TITLE
prevent fullscreen focus drifting

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -1696,7 +1696,7 @@ focusstack(const Arg *arg)
 {
 	Client *c = NULL, *i;
 
-	if (!selmon->sel || selmon->sel->isfullscreen)
+	if (!selmon->sel || (selmon->sel->isfullscreen && !selmon->sel->isfakefullscreen))
 		return;
 	if (arg->i > 0) {
 		for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);

--- a/instantwm.c
+++ b/instantwm.c
@@ -1696,7 +1696,7 @@ focusstack(const Arg *arg)
 {
 	Client *c = NULL, *i;
 
-	if (!selmon->sel)
+	if (!selmon->sel || selmon->sel->isfullscreen)
 		return;
 	if (arg->i > 0) {
 		for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);


### PR DESCRIPTION
If you right now open a fullscreen application (e.g. fullscreen youtube video in Firefox) and press Mod + J to change focus, InstantWM will happily change focus to the new window, but does not actually display it or exit fullscreen. The side effect is that your focus is now on the next window of the stack, so pressing esc (in the firefox example) to exit fullscreen wont work, since the new window is focused, this PR corrects this behaviour by disabling the changing of focus, when the selected window is in fullscreen. 
Another way to handle this would be to exit fullscreen and focus the new window.