### PR TITLE
Enhancement: comboview

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -125,7 +125,7 @@ static const Layout layouts[] = {
 /* key definitions */
 #define MODKEY Mod4Mask
 #define TAGKEYS(KEY, TAG)                                          \
-		{MODKEY, KEY, view, {.ui = 1 << TAG}},                     \
+		{MODKEY, KEY, comboview, {.ui = 1 << TAG}},                     \
 		{MODKEY | ControlMask, KEY, toggleview, {.ui = 1 << TAG}}, \
 		{MODKEY | ShiftMask, KEY, tag, {.ui = 1 << TAG}},          \
 		{MODKEY | Mod1Mask, KEY, followtag, {.ui = 1 << TAG}},          \

--- a/instantwm.c
+++ b/instantwm.c
@@ -50,6 +50,8 @@ static int freealttab = 0;
 
 static Client *lastclient;
 
+
+static int combo = 0;
 static int tagprefix = 0;
 static int bardragging = 0;
 static int altcursor = 0;
@@ -117,6 +119,7 @@ struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
 
 void
 keyrelease(XEvent *e) {
+	combo = 0;
 }
 
 int overlayexists() {
@@ -3951,6 +3954,33 @@ int computeprefix(const Arg *arg) {
 		return arg->ui << 10;
 	} else {
 		return arg->ui;
+	}
+}
+
+void
+comboview(const Arg *arg) {
+	unsigned newtags = arg->ui & TAGMASK;
+	int ui = computeprefix(arg);
+	int i;
+
+	if (combo) {
+		selmon->tagset[selmon->seltags] |= newtags;
+		focus(NULL);
+		arrange(selmon);
+	} else {
+		combo = 1;
+
+		view(arg);
+		// view returns prematurely if the current tag is the tag to view
+		// this does not matter for view itself, here tho it matters, because a window
+		// from another tag will not get send to its tag visually, so you will have an
+		// unfocusable ghost window. 
+		// TODO: improve this, as it seems like a hack
+		for (i = 0; !(ui & 1 << i); i++) ;
+        if ((i + 1) == selmon->pertag->curtag) {
+			focus(NULL);
+			arrange(selmon);
+		}
 	}
 }
 

--- a/instantwm.h
+++ b/instantwm.h
@@ -271,6 +271,7 @@ void sigchld(int unused);
 void spawn(const Arg *arg);
 void clickstatus(const Arg *arg);
 Monitor *systraytomon(Monitor *m);
+void comboview(const Arg *arg);
 void tag(const Arg *arg);
 void tagall(const Arg *arg);
 void followtag(const Arg *arg);


### PR DESCRIPTION
This PR adds a new detail to the way you view tags: combos.
So to view multiple tags you just press mod + all the tags you want to see.
e.g. MOD + 1 + 2 + 3 to view tags one, two and three.

One thing, worth thinking about is if animations should be disabled/speed up during this, as the slow animation speed of windows in the stack causes the combo selection to feel kind of laggy when trying to view 3 or more tags, because you have to wait for every window animation (if the window is stacked) to finish before another tags gets displayed. As I don't often use this feature with more than 2 tags, I left it as is and welcome feedback.