### PR TITLE
Fix some color problems

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -199,7 +199,7 @@ ResourcePref resources[] = {
 		{ "darkminimize",    STRING,  &col_dark_orange },
 
 		{ "border",        STRING,  &col_pastel_blue },
-		{ "activeborder",        STRING,  &col_blue },
+		{ "activeborder",        STRING,  &col_light_blue },
 
 		{ "activetag",        STRING,  &col_green },
 		{ "darkactivetag",        STRING,  &col_dark_green },

--- a/instantwm.c
+++ b/instantwm.c
@@ -1502,7 +1502,7 @@ drawbar(Monitor *m)
 						} else {
 							XSetForeground(drw->dpy, drw->gc, drw->scheme[ColFg].pixel);
 							XFillRectangle(drw->dpy, drw->drawable, drw->gc, x +  6, (bh - 20) / 2 - 2, 20, 16);
-							XSetForeground(drw->dpy, drw->gc, drw->scheme[ColBg].pixel);
+							XSetForeground(drw->dpy, drw->gc, drw->scheme[ColBorder].pixel);
 							XFillRectangle(drw->dpy, drw->drawable, drw->gc, x + 6, (bh - 20) / 2 + 14, 20, 6);
 						}
 					} else {


### PR DESCRIPTION
When trying to theme the window manager using Xresources, I noticed that the active window border color and the close button shadow when hovering didn't actually change to the correct color. This patch just fixes those issues.