### PR TITLE
Adds reverse master functionality to instantWM

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -4,6 +4,7 @@
 /* appearance */
 static const unsigned int borderpx = 3;		  /* border pixel of windows */
 static const unsigned int snap = 32;		  /* snap pixel */
+static const unsigned int rmaster        = 0; /* 1 means master-area is initially on the left, as default; change to 1 to set to right */
 static const unsigned int startmenusize = 30;		  /* snap pixel */
 static const unsigned int systraypinning = 0; /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
 static const unsigned int systrayspacing = 0; /* systray spacing */
@@ -283,6 +284,7 @@ static Key keys[] = {
 	{MODKEY|ShiftMask,				XK_Escape,  	spawn,	{.v = systemmonitorcmd}},
 
 	{MODKEY, XK_r, spawn, {.v = rangercmd } },
+	{MODKEY|ShiftMask, XK_r, togglermaster, {0} },
 	{MODKEY|ControlMask|Mod1Mask, XK_r, redrawwin, {0} },
 	{MODKEY, XK_n, spawn, {.v = nautiluscmd } },
 	{MODKEY | ControlMask, XK_q, spawn, {.v = instantshutdowncmd } },

--- a/instantwm.c
+++ b/instantwm.c
@@ -1147,6 +1147,7 @@ createmon(void)
 	m->tagset[0] = m->tagset[1] = 1;
 	m->mfact = mfact;
 	m->nmaster = nmaster;
+	m->rmaster = rmaster;
 	m->showbar = showbar;
 	m->topbar = topbar;
 	m->clientcount = 0;
@@ -4620,6 +4621,16 @@ changefloating(Client *c)
 		c->sfh = c->h;
 	}
 	arrange(selmon);
+}
+
+void
+togglermaster(const Arg *arg)
+{
+	selmon->rmaster = !selmon->rmaster;
+	/* now mfact represents the left factor */
+	selmon->mfact = 1.0 - selmon->mfact;
+	if (selmon->lt[selmon->sellt]->arrange)
+		arrange(selmon);
 }
 
 void

--- a/instantwm.h
+++ b/instantwm.h
@@ -132,6 +132,7 @@ struct Monitor {
 	unsigned int seltags;
 	unsigned int sellt;
 	unsigned int tagset[2];
+    unsigned int rmaster;
 	unsigned int activeoffset;
 	unsigned int titleoffset;
 	unsigned int clientcount;
@@ -301,6 +302,7 @@ void togglelocked(const Arg *arg);
 void toggleshowtags(const Arg *arg);
 void togglebar(const Arg *arg);
 void togglefloating(const Arg *arg);
+void togglermaster(const Arg *arg);
 void togglesticky(const Arg *arg);
 void toggleprefix(const Arg *arg);
 void toggletag(const Arg *arg);

--- a/layouts.c
+++ b/layouts.c
@@ -362,7 +362,9 @@ tile(Monitor *m)
 		return;
 
 	if (n > m->nmaster)
-		mw = m->nmaster ? m->ww * m->mfact : 0;
+		mw = m->nmaster
+            ? m->ww * (m->rmaster ? 1.0 - m->mfact : m->mfact)
+            : 0;
 	else {
 		mw = m->ww;
 		if (n > 1 && n < m->nmaster) {
@@ -375,7 +377,8 @@ tile(Monitor *m)
 		if (i < m->nmaster) {
 			// client is in the master
 			h = (m->wh - my) / (MIN(n, m->nmaster) - i);
-			animateclient(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), framecount, 0);
+			animateclient(c, m->rmaster ? m->wx + m->ww - mw : m->wx,
+                    m->wy + my, mw - (2*c->bw), h - (2*c->bw), framecount, 0);
 			if (m->nmaster == 1 && n > 1) {
 				mw = c->w + c->bw * 2;
 			}
@@ -384,7 +387,8 @@ tile(Monitor *m)
 		} else {
 			// client is in the stack
 			h = (m->wh - ty) / (n - i);
-			animateclient(c, m->wx + mw, m->wy + ty, m->ww - mw - (2*c->bw), h - (2*c->bw), framecount, 0);
+			animateclient(c, m->rmaster ? m->wx : m->wx + mw,
+                    m->wy + ty, m->ww - mw - (2*c->bw), h - (2*c->bw), framecount, 0);
 			if (ty + HEIGHT(c) < m->wh)
 				ty += HEIGHT(c);
 		}


### PR DESCRIPTION
It is taken from *dwm/rmaster* patch and adapted to instantWM code. When enabled, the master are will be on the right, the slave area on the left side.

It adds a new variable *rmaster* to config.def.h, which allows setting the reverse master layout as default after recompilation. It does not add a separate layout, just reverses the tile layout setup. Thus, it applies only to Tile layout, no other.