### PR TITLE
helptext for instantwmctrl

### DIFF
--- a/instantwmctrl.sh
+++ b/instantwmctrl.sh
@@ -1,24 +1,46 @@
 #!/usr/bin/env bash
+description="$0 <command> <args>...
 
-# really basic tool to send commands to instantWM
+Really basic tool to send commands to instantWM.
 
-case $1 in
-layout)
-    if [[ $2 =~ ^[0-8]$ ]]; then # between zero and eight?
-        layout=$2
-    else
-        declare -A layouts=(
-          ["tile"]=0 ['grid']=1 ['float']=2 
-          ['monocle']=3 ['tcl']=4 ['deck']=5
-          ['overview']=6 ['bstack']=7 ['bstackhoriz']=8
-        )
-        layout=${layouts[$2]}
-        [ -z "$layout" ] &&
-          { echo "Error: Unknown layout '$2'"; exit 1; }
-    fi 
-    xsetroot -name "c;:;layout;$layout"
-    exit
-    ;;
-esac
+Commands:
+    help                     Display this help text
+    layout <number>|<name>   Change window layout to given argument, e.g. $0 layout monocle"
 
-xsetroot -name "c;:;$1;$2"
+main() {
+    case $1 in
+        help) usage -h ;;
+
+        layout)
+            if [[ $2 =~ ^[0-8]$ ]]; then # between zero and eight?
+                layout=$2
+            else
+                declare -A layouts=(
+                ["tile"]=0 ['grid']=1 ['float']=2 
+                ['monocle']=3 ['tcl']=4 ['deck']=5
+                ['overview']=6 ['bstack']=7 ['bstackhoriz']=8
+                )
+                layout=${layouts[$2]}
+                [ -z "$layout" ] &&
+                { echo "Error: Unknown layout '$2'"; exit 1; }
+            fi 
+            xsetroot -name "c;:;layout;$layout"
+            exit
+        ;;
+    esac
+    xsetroot -name "c;:;$1;$2"
+}
+
+usage() {
+    for itm in "$@"; do
+    if [[ "$itm" =~ ^(-h|--help|-help|-\?)$ ]]; then
+        1>&2 echo "Usage: $description"; exit 0;
+    fi
+    done
+}
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+    usage "$@"
+    main "$@"
+fi
+

--- a/instantwmctrl.sh
+++ b/instantwmctrl.sh
@@ -5,7 +5,15 @@ Really basic tool to send commands to instantWM.
 
 Commands:
     help                     Display this help text
-    layout <number>|<name>   Change window layout to given argument, e.g. $0 layout monocle"
+    overlay
+    tag
+    animated
+    alttab
+    layout <number>|<name>   Change window layout to given argument, e.g. $0 layout monocle
+    prefix
+    allttag
+    hidetags"
+
 
 main() {
     case $1 in

--- a/instantwmctrl.sh
+++ b/instantwmctrl.sh
@@ -10,25 +10,25 @@ Commands:
 main() {
     case $1 in
         help) usage -h ;;
-
-        layout)
-            if [[ $2 =~ ^[0-8]$ ]]; then # between zero and eight?
-                layout=$2
-            else
-                declare -A layouts=(
-                ["tile"]=0 ['grid']=1 ['float']=2 
-                ['monocle']=3 ['tcl']=4 ['deck']=5
-                ['overview']=6 ['bstack']=7 ['bstackhoriz']=8
-                )
-                layout=${layouts[$2]}
-                [ -z "$layout" ] &&
-                { echo "Error: Unknown layout '$2'"; exit 1; }
-            fi 
-            xsetroot -name "c;:;layout;$layout"
-            exit
-        ;;
+        layout) layout $2; exit ;;
     esac
     xsetroot -name "c;:;$1;$2"
+}
+
+layout() {
+    if [[ $1 =~ ^[0-8]$ ]]; then # between zero and eight
+        layout=$1
+    else
+        declare -A layouts=(
+            ["tile"]=0 ['grid']=1 ['float']=2 
+            ['monocle']=3 ['tcl']=4 ['deck']=5
+            ['overview']=6 ['bstack']=7 ['bstackhoriz']=8
+        )
+        layout=${layouts[$1]}
+        [ -z "$layout" ] &&
+            { echo "Error: Unknown layout '$1'"; exit 1; }
+    fi 
+    xsetroot -name "c;:;layout;$layout"
 }
 
 usage() {


### PR DESCRIPTION
Add a help text to `instantwmctrl`. It can be displayed with either of `-h`, `-help`, `--help`, `-?` and `help` as argument.

One can also savely `source instantwmctrl.sh` in other scripts and then run it's main or sub functions.

Note that the commands other than `help` and `layout` still need argument definitions and descriptions, but I'm not 100% sure what they all take and do.