### PR TITLE
Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ instantWM the window manager of instantOS.
 
 ## Installation
 
-It is preinstalled on instantOS  
+It is preinstalled on instantOS
 You can manually install the git build by cloning the repo and then running build.sh
 
 ```sh
@@ -20,7 +20,7 @@ cd instantWM
 
 [Download latest release](https://github.com/instantOS/instantWM/releases/download/beta2/instantwm.pkg.tar.xz)
 
-## [Documentation](instantos.io/document)
+## [Documentation](https://instantos.io/documentation)
 
 Documentation for instantWM can be found in the general documentation for
 instantOS and the instructional screencasts.  It is not described in this


### PR DESCRIPTION
The current link for documentation goes to a URL with a 404 error message (https://github.com/instantOS/instantWM/blob/master/instantos.io/document). I've updated it to go to the documentation found on the main site (https://instantos.io/documentation)