### PR TITLE
make version message compliant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 config.h
 instantwm
 tags
+.envrc
+shell.nix

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ options:
 	@echo "CFLAGS   = ${CFLAGS}"
 	@echo "LDFLAGS  = ${LDFLAGS}"
 	@echo "CC       = ${CC}"
+	@echo "VERSION  = ${VERSION}"
 
 .c.o:
 	${CC} -c ${CFLAGS} $<

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,6 @@
 # instantWM version
-VERSION = instantOS-beta
+CMS_VERSION := $(shell git describe --abbrev=5 --dirty=-dev --always --tags 2>/dev/null || echo "unknown")
+VERSION := "instantOS $(CMS_VERSION) - Build $(shell LANG=en_us_8859_1 date '+%a, %b %e %Y, %R:%S %z') on $(shell hostname 2>/dev/null || echo "unknown host")"
 
 # Customize below to fit your system
 

--- a/instantwm.c
+++ b/instantwm.c
@@ -5927,9 +5927,11 @@ load_xresources(void)
 int
 main(int argc, char *argv[])
 {
-	if (argc == 2 && !strcmp("-v", argv[1]))
-		die("instantwm-"VERSION);
-	else if (argc != 1)
+	if ( argc == 2
+            && (!strcmp("-v", argv[1]) || !strcmp("--version", argv[1]) ) ) {
+		puts("instantwm-"VERSION"\n");
+        return EXIT_SUCCESS;
+    } else if (argc != 1)
 		die("usage: instantwm [-v]");
 	if (!setlocale(LC_CTYPE, "") || !XSupportsLocale())
 		fputs("warning: no locale support\n", stderr);

--- a/instantwm.c
+++ b/instantwm.c
@@ -5928,7 +5928,7 @@ int
 main(int argc, char *argv[])
 {
 	if ( argc == 2
-            && (!strcmp("-v", argv[1]) || !strcmp("--version", argv[1]) ) ) {
+            && (!strcmp("-V", argv[1]) || !strcmp("--version", argv[1]) ) ) {
 		puts("instantwm-"VERSION"\n");
         return EXIT_SUCCESS;
     } else if (argc != 1)


### PR DESCRIPTION
POSIX either requires or recommends:

 - The exit code be 0 for the version option
 - The short option to have the capital letter `-V` (as `-v` is for verbose output) 
 - A long `--version` be present
 - The actual version be space separated from the program name and possible additional information

Accordingly, this PR will changes the output to:

![image](https://user-images.githubusercontent.com/11145016/101174425-2b79a300-3644-11eb-9bef-dbcc8e037efc.png)

Note that it provides additional information now, too, e.g. the short commit hash and build time.

@paperbenni, you might want to tag the actual beta 6 commit with `git tag -a -m "beta6" <commit_hash> && git push --tags`, so the correct version (which atm. is beta 6?) is displayed.