### PR TITLE
Removes redundant check

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -5860,11 +5860,10 @@ zoom(const Arg *arg)
 
 	XRaiseWindow(dpy, c->win);
 	if (!selmon->lt[selmon->sellt]->arrange
-	|| (selmon->sel && selmon->sel->isfloating))
+	|| (selmon->sel && selmon->sel->isfloating)
+	|| (c == nexttiled(selmon->clients)
+	|| !(c = nexttiled(c->next)))
 		return;
-	if (c == nexttiled(selmon->clients))
-		if (!c || !(c = nexttiled(c->next)))
-			return;
 	pop(c);
 }
 


### PR DESCRIPTION
`!c` was checked at the start, and does not need to be checked again on 5866. 

After rewriting, the expression `!(c = nexttiled(c->next))` looks off to me. Is the assignment intended? If so, was the original value of `c` supposed to be called with `pop`. It just seems odd that all the logic was base on checking `selmon->sel` (`c`'s initial value), for us to then to perform an action on the result of value equal to `nexttiled(selmon->sel->next)`.