### PR TITLE
Redundant check fix and refactor

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -5860,13 +5860,13 @@ zoom(const Arg *arg)
 
 	XRaiseWindow(dpy, c->win);
 	if (!selmon->lt[selmon->sellt]->arrange
-	|| (selmon->sel && selmon->sel->isfloating))
+	|| (selmon->sel && selmon->sel->isfloating)
+	|| (c == nexttiled(selmon->clients))
+	|| !(c = nexttiled(c->next)))
 		return;
-	if (c == nexttiled(selmon->clients))
-		if (!c || !(c = nexttiled(c->next)))
-			return;
 	pop(c);
 }
+
 
 
 void

--- a/layouts.c
+++ b/layouts.c
@@ -203,6 +203,19 @@ monocle(Monitor *m)
 void
 focusstack2(const Arg *arg)
 {
+	Client *nextVisibleClient = findVisibleClient(selmon->sel->next) ?: findVisibleClient(selmon->clients);
+
+	if (nextVisibleClient) {
+		if (nextVisibleClient->mon != selmon)
+			selmon = nextVisibleClient->mon;
+		detachstack(nextVisibleClient);
+		attachstack(nextVisibleClient);
+		selmon->sel = nextVisibleClient;
+	}
+}
+void
+focusstack2(const Arg *arg)
+{
 	Client *c = NULL;
 
 	for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);

--- a/layouts.c
+++ b/layouts.c
@@ -213,26 +213,6 @@ focusstack2(const Arg *arg)
 		selmon->sel = nextVisibleClient;
 	}
 }
-void
-focusstack2(const Arg *arg)
-{
-	Client *c = NULL;
-
-	for (c = selmon->sel->next; c && !ISVISIBLE(c); c = c->next);
-	if (!c)
-		for (c = selmon->clients; c && !ISVISIBLE(c); c = c->next);
-
-	if (c) {
-		if (c) {
-			if (c->mon != selmon)
-				selmon = c->mon;
-			detachstack(c);
-			attachstack(c);
-		}
-
-		selmon->sel = c;
-	}
-}
 
 void
 overviewlayout(Monitor *m)

--- a/layouts.h
+++ b/layouts.h
@@ -12,5 +12,11 @@ void overviewlayout(Monitor *m);
 void tcl(Monitor * m);
 void tile(Monitor *m);
 void floatl(Monitor *m);
-
+static inline Client* findVisibleClient(Client *c){
+	for (Client* client = c; client ; client = client->next){
+		if(ISVISIBLE(client))
+			return client;
+	}
+	return NULL;
+}
 #endif

--- a/layouts.h
+++ b/layouts.h
@@ -13,7 +13,8 @@ void tcl(Monitor * m);
 void tile(Monitor *m);
 void floatl(Monitor *m);
 static inline Client* findVisibleClient(Client *c){
-	for (Client* client = c; client ; client = client->next){
+	Client* client = NULL;
+	for (client = c; client ; client = client->next){
 		if(ISVISIBLE(client))
 			return client;
 	}


### PR DESCRIPTION
Uses added function `findVisibleClient` and the Elvis operator to hide some logic. Also, removes some redundant checks. 

 [Elivs](https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Conditionals.html#Conditionals) depends on a gcc extension resulting in a warning from` -wpedantic`. 

