### PR TITLE
factor in monitor vertical coordinate with floating mode

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -657,6 +657,7 @@ applyrules(Client *c)
                         break;;
                     case 1:
                         c->isfloating = 1;
+                        c->y = c->mon->my + ( selmon->showbar ? bh : 0 );
                         break;;
                     case 0:
                         c->isfloating = 0;
@@ -2212,7 +2213,7 @@ manage(Window w, XWindowAttributes *wa)
 	updatemotifhints(c);
 
 	c->sfx = c->x;
-	c->sfy = c->y;
+	c->sfy = c->y >= c->mon->my ? c->y : c->y + c->mon->my;
 	c->sfw = c->w;
 	c->sfh = c->h;
 	XSelectInput(dpy, w, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask);


### PR DESCRIPTION
*    Fixes clients' Y coordinate when spawning with isfloating 1
*    Fixes clients' Y coordinate when toggling from tiling to floating
     mode first time

> This check is to prevent the client from having it's height increased by monitor Y coord (This only happens when restarting the WM)
> Usually fresh client spawn it's going to set client's `sfy` as client's `y` + monitor `y`
```
c->sfy = c->y >= c->mon->my ? c->y : c->y + c->mon->my;
```

### Once again, this is specific to my monitor setup where I've 2 monitors with different height