### PR TITLE
forcefully reset last floating position before floating the client added to scratchpad

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -4815,9 +4815,11 @@ void createscratchpad(const Arg *arg) {
 
 	c->tags = 1 << 20;
 	c->issticky = selmon->scratchvisible;
-	if (!c->isfloating)
+	if (!c->isfloating) {
+		c->sfy = c->mon->my + ( selmon->showbar ? bh : 0 );
+		c->sfx = c->mon->mx;
 		togglefloating(NULL);
-	else
+	} else
 		arrange(selmon);
 	focus(NULL);
     if (!selmon->scratchvisible) {


### PR DESCRIPTION
```forcefully reset last floating position before floating the client added to scratchpad```

Might not be the best approach but this fixes the issue where the scratchpad is out of the monitor y/x with different height/width multimonitor setup

This happens when you:
- add client to sratchpad
- snap it to the top bar
- add client to scratchpad again
- now it's y position is the saved one which corresponds to the biggest monitor height as with a smaller height monitor
clients can go out of the visible way / out of the monitor boundaries