### PR TITLE
fix client spawning outside of monitor (Y coord) when the initial tag layout is floating

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -2213,7 +2213,7 @@ manage(Window w, XWindowAttributes *wa)
 	updatemotifhints(c);
 
 	c->sfx = c->x;
-	c->sfy = c->y >= c->mon->my ? c->y : c->y + c->mon->my;
+	c->sfy = c->y = c->y >= c->mon->my ? c->y : c->y + c->mon->my;
 	c->sfw = c->w;
 	c->sfh = c->h;
 	XSelectInput(dpy, w, EnterWindowMask|FocusChangeMask|PropertyChangeMask|StructureNotifyMask);


### PR DESCRIPTION
As the title says, it fixes the initial client Y coordinate position when spawning with the floating layout on the tag
Not sure why https://github.com/instantOS/instantWM/pull/69 doesn't factor in this case. My guess is that probably the client doesn't actually spawn with isfloating 1.

This could be result in being a bad approach then.