### PR TITLE
fix moveresize Y coordinate boundaries

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -4600,11 +4600,11 @@ moveresize(const Arg *arg) {
 
 	if (nx < selmon->mx)
 		nx = selmon->mx;
-	if (ny < 0)
-		ny = 0;
+	if (ny < selmon->my)
+		ny = selmon->my;
 
-	if ((ny + c->h) > selmon->mh)
-		ny = (selmon->mh - c->h);
+	if ((ny + c->h) > (selmon->my + selmon->mh))
+		ny = ((selmon->mh + selmon->my) - c->h);
 
 	if ((nx + c->w) > (selmon->mx + selmon->mw))
 		nx = ((selmon->mw + selmon->mx) - c->w);


### PR DESCRIPTION
- Fixes upper boundary so you can't moveresize the window out of the monitor 'view'
- Fixes weird behaviour of moveresize with the dual monitor setup with different heights