### PR TITLE
add notification keybinds

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -160,6 +160,9 @@ static const char *keylayoutswitchcmd[] = {"instantkeyswitch", NULL};
 static const char *iswitchcmd[] = {"iswitch", NULL};
 static const char *instantswitchcmd[] = {"rofi", "-show", "window", "-kb-row-down", "Alt+Tab,Down", "-kb-row-up", "Alt+Ctrl+Tab,Up", "-kb-accept-entry", "!Alt_L,!Alt+Tab,Return", "-me-select-entry", "", "-me-accept-entry", "MousePrimary", NULL};
 static const char *caretinstantswitchcmd[] = {"rofi", "-show", "window", "-kb-row-down", "Alt+Tab,Down", "-kb-row-up", "Alt+Ctrl+Tab,Up", "-kb-accept-entry", "!Alt_L,!Alt+Tab,Return", "-me-select-entry", "", "-me-accept-entry", "MousePrimary", "-theme", "/usr/share/instantdotfiles/rofi/appmenu.rasi", NULL};
+static const char *notificationclose[] = {"dunstctl", "close", NULL};
+static const char *notificationpop[] = {"dunstctl", "history-pop", NULL};
+static const char *notificationaction[] = {"dunstctl", "context", NULL};
 static const char *onboardcmd[] = {"onboard", NULL};
 static const char *instantshutdowncmd[] = {"instantshutdown", NULL};
 static const char *systemmonitorcmd[] = {".config/instantos/default/systemmonitor", NULL};
@@ -280,6 +283,9 @@ static Key dkeys[] = {
 static Key keys[] = {
 	/* modifier                             key                 function              argument */
 
+	{MODKEY|ControlMask,                    XK_Up,              spawn,                {.v = notificationclose}},
+	{MODKEY|ControlMask,                    XK_Down,            spawn,                {.v = notificationpop}},
+	{MODKEY|ControlMask,                    XK_Return,          spawn,                {.v = notificationaction}},
 	{MODKEY|Mod1Mask,                       XK_j,               keyresize,            {.i = 0}},
 	{MODKEY|Mod1Mask,                       XK_k,               keyresize,            {.i = 1}},
 	{MODKEY|Mod1Mask,                       XK_l,               keyresize,            {.i = 2}},


### PR DESCRIPTION
Current keybindings:

- super + ctrl + up to close most recent notification
- super + ctrl + down to pull notifications from history
- super + ctrl + enter to open the context menu for action

Things that can change:
 - Keys
 - Adding close all (`dunstctl close-all`)
 - Possibly removing the history part if it is not wanted

If this does get approved, changing the `history_length` option in `dunstrc` to make the history part more useful would make sense.
