### PR TITLE
Added titlebar dragging

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -2998,7 +2998,7 @@ dragmouse(const Arg *arg)
 		int prev_slot = -1;
 		int tempanim = animated;
 		animated = 0;
-		tagwidth = gettagwidth();
+		drawbar(c->mon);
 		do {
 			XMaskEvent(dpy, MOUSEMASK|ExposureMask|SubstructureRedirectMask, &ev);
 			switch(ev.type) {

--- a/instantwm.c
+++ b/instantwm.c
@@ -2996,9 +2996,9 @@ dragmouse(const Arg *arg)
 
 	if (tabdragging) {
 		int prev_slot = -1;
-		int switched = 0;
 		int tempanim = animated;
 		animated = 0;
+		tagwidth = gettagwidth();
 		do {
 			XMaskEvent(dpy, MOUSEMASK|ExposureMask|SubstructureRedirectMask, &ev);
 			switch(ev.type) {
@@ -3016,24 +3016,21 @@ dragmouse(const Arg *arg)
 					break;
 				}
 				int x = ev.xmotion.x_root;
-				int left = selmon->mx + tagwidth + startmenusize;
+				// startmenu + tags + layout indicator
+				int left = selmon->mx + startmenusize + tagwidth + bh;
 				int right = left + selmon->btw;
-				if (x < left || x > right) {
+				if (x < left || x >= right) {
 					tabdragging = 0;
 					break;
 				}
 				int slot = (x - left) * selmon->bt / selmon->btw;
 				if (slot != prev_slot) {
-					switched = 1;
 					prev_slot = slot;
 					detach(c);
-					int i = 0;
-					// walk to slot #
+					// walk down linked list to the slot #
 					Client **tc = &selmon->clients;
-					while (*tc && i < slot) {
+					for (int i = 0; i < slot && *tc; i++)
 						tc = &(*tc)->next;
-						i++;
-					}
 					c->next = *tc;
 					*tc = c;
 					arrange(selmon);
@@ -3041,7 +3038,6 @@ dragmouse(const Arg *arg)
 				break;
 			case ButtonRelease:
 				dragging = 0;
-				tabdragging = switched;
 			}
 		} while (dragging && tabdragging);
 		animated = tempanim;

--- a/instantwm.c
+++ b/instantwm.c
@@ -3029,8 +3029,12 @@ dragmouse(const Arg *arg)
 					detach(c);
 					// walk down linked list to the slot #
 					Client **tc = &selmon->clients;
-					for (int i = 0; i < slot && *tc; i++)
+					int i = 0;
+					while (i < slot && *tc) {
+						if (*tc && ISVISIBLE((*tc)))
+							i++;
 						tc = &(*tc)->next;
+					}
 					c->next = *tc;
 					*tc = c;
 					arrange(selmon);

--- a/instantwm.c
+++ b/instantwm.c
@@ -2983,7 +2983,7 @@ dragmouse(const Arg *arg)
                                abs((startx - ev.xmotion.x_root) *
                                    (startx - ev.xmotion.x_root))) > 4069) {
                             dragging = 1;
-							if (barheight ? ev.xmotion.y_root < barheight : ev.xmotion.y_root < 12) {
+							if (ev.xmotion.y_root < bh) {
 								tabdragging = 1;
 							}
 						  }
@@ -3011,7 +3011,7 @@ dragmouse(const Arg *arg)
 				if ((ev.xmotion.time - lasttime) <= (1000 / 60))
 					continue;
 				lasttime = ev.xmotion.time;
-				if (barheight ? ev.xmotion.y_root >= barheight : ev.xmotion.y_root >= 12) {
+				if (ev.xmotion.y_root >= bh) {
 					tabdragging = 0;
 					break;
 				}


### PR DESCRIPTION
Sort of addresses #47

Dragging the title bar sideways will allow you to reorder the clients with the mouse. If you move the mouse off of the bar, it will revert to the old mouse movement behavior, which feels a bit weird, but I don't know what else it should have done.

https://streamable.com/xp24ko

It's pretty messy, so I understand if you don't want to merge it directly, or if you want to put it behind a toggleable option, or if the behavior in edge cases needs to be different.