### PR TITLE
Add montior focus-related commands to instanwmctrl and fix bug for commands with common prefix

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -224,18 +224,21 @@ ResourcePref resources[] = {
 
 static Xcommand commands[] = {
 	/* signum       function        default argument  arg handler*/
-    // 0 means off, 1 means toggle, 2 means on
+	// 0 means off, 1 means toggle, 2 means on
 	{ "overlay",                setoverlay,                   {0},         0 },
 	{ "tag",                    view,                         { .ui = 2 }, 3 },
 	{ "animated",               toggleanimated,               { .ui = 2 }, 1 },
-    { "focusfollowsmouse",      togglefocusfollowsmouse,      { .ui = 2 }, 1 },
-    { "focusfollowsfloatmouse", togglefocusfollowsfloatmouse, { .ui = 2 }, 1 },
+	{ "focusfollowsmouse",      togglefocusfollowsmouse,      { .ui = 2 }, 1 },
+	{ "focusfollowsfloatmouse", togglefocusfollowsfloatmouse, { .ui = 2 }, 1 },
 	{ "alttab",                 alttabfree,                   { .ui = 2 }, 1 },
 	{ "layout",                 commandlayout,                { .ui = 0 }, 1 },
 	{ "prefix",                 commandprefix,                { .ui = 1 }, 1 },
 	{ "alttag",                 togglealttag,                 { .ui = 0 }, 1 },
 	{ "hidetags",               toggleshowtags,               { .ui = 0 }, 1 },
 	{ "specialnext",            setspecialnext,               { .ui = 0 }, 3 },
+	{ "tagmon",                 tagmon,                       { .i = +1 }, 0 },
+	{ "followmon",              followmon,                    { .i = +1 }, 0 },
+	{ "focusmon",               focusmon,                     { .i = +1 }, 0 },
 };
 
 static Key dkeys[] = {

--- a/instantwm.c
+++ b/instantwm.c
@@ -124,18 +124,6 @@ void
 keyrelease(XEvent *e) {
 }
 
-void
-printArg(char *s, const Arg *arg) {
-    FILE * tmplog = fopen("/tmp/instantfocus.log", "a");
-    if(tmplog == NULL) perror("printArg: cannot opent logilfe!");
-    if (arg == NULL)
-    fprintf(tmplog, "%s\n", s);
-    else
-    fprintf(tmplog, "%s\n" "i: %i\n" "ui: %u\n" "f: %f\n" "*v: %p\n",
-	            s,     arg->i,    arg->ui,  arg->f,   arg->v     );
-    fclose(tmplog);
-}
-
 int overlayexists() {
 	Client *c;
 	Monitor *m;
@@ -1838,7 +1826,6 @@ focusin(XEvent *e)
 void
 followmon(const Arg *arg)
 {
-        printArg("followmon", arg);
 	Client *c;
 	if (!selmon->sel)
 		return;
@@ -1854,7 +1841,6 @@ followmon(const Arg *arg)
 void
 focusmon(const Arg *arg)
 {
-        printArg("focusmon", arg);
 	Monitor *m;
 
 	if (!mons->next)
@@ -2142,19 +2128,13 @@ xcommand()
     }
     fcursor = command + strlen(indicator); // got command for us, strip indicator
 
-    printArg("\n===========", NULL);
-    printArg(command, NULL);
     // Check if a command was found, and if so handle it
     for (i = 0; i < LENGTH(commands); i++) {
-	printArg("\n", NULL);
-	printArg(commands[i].cmd, NULL);
-	printArg(fcursor, NULL);
         if ( !startswith(fcursor, commands[i].cmd) )
 	    continue;
         
 	fcursor += strlen(commands[i].cmd);
 	// no args
-	printArg("loop", &(commands[i].arg));
 	if (!strlen(fcursor)) {
 	    arg = commands[i].arg;
 	} else {
@@ -2186,7 +2166,6 @@ xcommand()
 		    break;
 	    }
 	}
-	printArg("execute", &arg);
 	commands[i].func(&(arg));
 	break;
     }
@@ -4444,7 +4423,6 @@ void resetsticky(Client *c) {
 void
 tagmon(const Arg *arg)
 {
-    printArg("tagmon", arg);
     if (!selmon->sel || !mons->next)
         return;
 

--- a/instantwmctrl.sh
+++ b/instantwmctrl.sh
@@ -6,15 +6,19 @@ Really basic tool to send commands to instantWM.
 Commands:
     help                     Display this help text
     overlay
-    tag
-    animated
+    tag <number>             Switch to tag described by <number>
+    animated                 Toggle animations
     alttab
     layout <number>|<name>   Change window layout to given argument, e.g. $0 layout monocle
     prefix
-    focusfollowsmouse        Control if window focus will change with mouse movement
+    focusfollowsmouse        Toggle window focus will change with mouse movement
+    focusfollowsfloatmouse   As above but only for flowting windows
+    focusmon                 Switch focus to other monitor
+    tagmon                   Move window to other monitor
+    followmon                As above but follow focus
     allttag
     hidetags"
-
+# See config.def.c and look for "Xcommand commands"
 
 main() {
     case $1 in


### PR DESCRIPTION
Adds monitor focus commands to instantwmctl, also includes a bufix:
In the old version, if you had commands named `focus` and `focusmon`, and the latter was before the former in `commands`, that could theoretically cause trouble if `focus` executed, because the code `focusmon` would falsely be executed.