### PR TITLE
Merge request to fix typo in `Makefile` that is of low importance, and request to merge a complete rewrite of `build.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ dist: clean
 
 .PHONY: install
 install: all
-	install -d ${DESTDIR}{${PREFIX}/bin,/usr/share/xsessions,${MANPREFIX}/man1}
+	install -d ${DESTDIR}${PREFIX}/bin
+	install -d ${DESTDIR}/usr/share/xsessions
+	install -d ${DESTDIR}${MANPREFIX}/man1
 	install -m  755 -s instantwm ${DESTDIR}${PREFIX}/bin/
 	install -Dm 755 instantwmctrl.sh ${DESTDIR}${PREFIX}/bin/instantwmctrl
 	ln -sf ${DESTDIR}${PREFIX}/bin/instantwmctrl ${DESTDIR}${PREFIX}/bin/instantwmctl

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ instantWM the window manager of instantOS.
 
 ![img](https://github.com/instantOS/instantLOGO/blob/master/screeenshots/screenshot1.png)
 
+## Scarbrough Branch
+
+The Scarbrough Branch is my personal brach of instantWM.  Chiefly, I seek to
+change the keybindings to be Dvorak compatible.
+
+Major differences:
+
+  1. Have fixed typo in `Makefile`.
+  2. Have rewritten `build.sh` to have more straight-forward and extended
+  functionality.
+
+`build.sh` now can iteratively backup `config.h` before compiling with the
+default `config.def.h`, and it now defaults to creating `config.h` if it does
+not exist, but then will not remove it unless specified.
+
 ## Installation
 
 It is preinstalled on instantOS

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,6 @@
 			make
 			"$SUPERU" make install
 		fi
-
 	}
 
 	delete_config() {

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,104 @@
 #!/usr/bin/env bash
 
-# compile and install instantWM
+################################################################################
+#                                                                              #
+#                         Compile and install instantWM                        #
+#                                                                              #
+################################################################################
 
-make clean &>/dev/null
+#==============================================================================#
+# ===FIND SUPERUSER PROGRAM===                                                 #
+#                                                                              #
+# Finds out whether to use `sudo` or `doas`.                                   #
+#==============================================================================#
 
-if [ -z "$2" ]; then
-    rm config.h &>/dev/null
-    make && sudo make install
-fi
+	if [[ -x /usr/bin/doas ]] && [[ -s /etc/doas.conf ]] ; then
+		SUPERU="doas"
+	else
+		SUPERU="sudo"
+	fi
+
+#==============================================================================#
+# ===FUNCTIONS===                                                              #
+#==============================================================================#
+
+	default_behavior() {
+		"$SUPERU" make install
+	}
+
+	default_config() {
+		if [[ -e config.h ]] && [[ ! -e config.h.orig ]]; then
+			mv config.h config.h.orig
+			make
+			"$SUPERU" make install
+		elif [[ -e config.h.orig ]] ; then
+			#------------------------------------------------------------------#
+			# This is an iteration function.  If `config.h.orig` exists, then  #
+			# for every instance of `config.h.orig` and beyond, add one iter-  #
+			# ation to the counter.  Once all iterations are done, then name   #
+			# `config.h` as:                                                   #
+			#                                                                  #
+			#     `config.h.orig.<iteration>`                                  #
+			#------------------------------------------------------------------#
+			i=0
+			for i2 in config.h.orig* ; do
+				let i++
+			done
+			mv config.h config.h.orig."$i"
+			make
+			"$SUPERU" make install
+		else
+			make
+			"$SUPERU" make install
+		fi
+
+	}
+
+	delete_config() {
+		rm config.h &>/dev/null && \
+		make && \
+		"$SUPERU" make install
+	}
+
+	get_help() {
+		echo "[1mbuild.sh[0m"
+		echo "Compile and install instantWM."
+		echo ""
+
+		echo "[1mUsage:[0m"
+		echo "    [1mbuild.sh[0m [[4mOPTIONS[0m]"
+		echo ""
+
+		echo "[1mOptions:[0m"
+		echo "   [2m-c[0m, [2m--custom-config[0m  -  Use [2mconfig.h[0m if available (default behaviour)"
+		echo "   [2m-d[0m, [2m--default-config[0m -  Backup [2mconfig.h[0m and recompile [2mconfig.def.h[0m"
+		echo "   [2m-D[0m, [2m--delete-config[0m  -  Delete [2mconfig.h[0m and recompile [2mconfig.def.h[0m"
+		echo "   [2m-h[0m, [2m--help[0m           -  Print this help menu"
+		echo ""
+		echo "Note: [2m-d[0m creates [3miterated[0m backups.  These stack up if not careful."
+		echo ""
+	}
+
+
+#==============================================================================#
+# ===CLEAN WORKING DIRECTORY===                                                #
+#==============================================================================#
+
+	make clean &>/dev/null
+
+
+#==============================================================================#
+# ===CASE STATEMENT===                                                         #
+#==============================================================================#
+
+	case "$@" in
+		--custom-config)  default_behavior ;;
+		 -c)              default_behavior ;;
+		--default-config) default_config   ;;
+		 -d)              default_config   ;;
+		--delete-config)  delete_config    ;;
+		 -D)              delete_config    ;;
+		--help)           get_help         ;;
+		 -h)              get_help         ;;
+		  *)              default_behavior ;;
+	esac

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,7 @@
 #==============================================================================#
 
 	default_behavior() {
+		make && \
 		"$SUPERU" make install
 	}
 
@@ -54,9 +55,14 @@
 	}
 
 	delete_config() {
-		rm config.h &>/dev/null && \
-		make && \
-		"$SUPERU" make install
+		if [[ -e config.h ]] ; then
+			rm config.h &>/dev/null && \
+			make && \
+			"$SUPERU" make install
+		else
+			make && \
+			"$SUPERU" make install
+		fi
 	}
 
 	get_help() {
@@ -75,7 +81,6 @@
 		echo "   [2m-h[0m, [2m--help[0m           -  Print this help menu"
 		echo ""
 		echo "Note: [2m-d[0m creates [3miterated[0m backups.  These stack up if not careful."
-		echo ""
 	}
 
 


### PR DESCRIPTION
Please refer to the most recent commit messages of both `Makefile` and `build.sh` for the most thorough information on what is changed and why.  `build.sh` shows three commits.  The last two were to fix typos I made before pushing the changes to my fork—I was simply unaware that git registered the commits before I wrote out the final message for the final commit.

`build.sh` now has _new_ default behaviour.   The old behaviour was hard-coded to delete `config.h` regardless of if it existed.  The new default behaviour creates `config.h` if it does not exist, and if it does exist, it is left alone unless the user manually deletes it.  The user also has the option to backup `config.h` before switching back to using `config.def.h`, and the user has the option to alternatively use the old default behaviour—delete `config.h` and used `config.def.h` without backing up.  If the user chooses the backup option, the backups generate iteratively.

For more information on usage, see:

    ./build.sh [-h|--help]

I apologize for this request also containing the changes to the `README.md` on my fork—I didn't think of to create a branch just for a pull request.

Please audit code carefully before considering.

Thank you.