### PR TITLE
switch back to previous tag when hitting the keybind for the currently selected tag

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -125,7 +125,7 @@ static const Layout layouts[] = {
 /* key definitions */
 #define MODKEY Mod4Mask
 #define TAGKEYS(KEY, TAG)                                          \
-		{MODKEY, KEY, view, {.ui = 1 << TAG}},                     \
+		{MODKEY, KEY, keyview, {.ui = 1 << TAG}},                     \
 		{MODKEY|ControlMask, KEY, toggleview, {.ui = 1 << TAG}}, \
 		{MODKEY|ShiftMask, KEY, tag, {.ui = 1 << TAG}},          \
 		{MODKEY|Mod1Mask, KEY, followtag, {.ui = 1 << TAG}},          \
@@ -270,15 +270,15 @@ static Key dkeys[] = {
 	{0,          XK_Up,     shiftview,   {.i = +1 } },
 	{0,          XK_Down,   shiftview,   {.i = -1 } },
 
-	{0,          XK_1,      view,        {.ui = 1 << 0}},
-	{0,          XK_2,      view,        {.ui = 1 << 1}},
-	{0,          XK_3,      view,        {.ui = 1 << 2}},
-	{0,          XK_4,      view,        {.ui = 1 << 3}},
-	{0,          XK_5,      view,        {.ui = 1 << 4}},
-	{0,          XK_6,      view,        {.ui = 1 << 5}},
-	{0,          XK_7,      view,        {.ui = 1 << 6}},
-	{0,          XK_8,      view,        {.ui = 1 << 7}},
-	{0,          XK_9,      view,        {.ui = 1 << 8}},
+	{0,          XK_1,      keyview,     {.ui = 1 << 0}},
+	{0,          XK_2,      keyview,     {.ui = 1 << 1}},
+	{0,          XK_3,      keyview,     {.ui = 1 << 2}},
+	{0,          XK_4,      keyview,     {.ui = 1 << 3}},
+	{0,          XK_5,      keyview,     {.ui = 1 << 4}},
+	{0,          XK_6,      keyview,     {.ui = 1 << 5}},
+	{0,          XK_7,      keyview,     {.ui = 1 << 6}},
+	{0,          XK_8,      keyview,     {.ui = 1 << 7}},
+	{0,          XK_9,      keyview,     {.ui = 1 << 8}},
 
 };
 

--- a/instantwm.c
+++ b/instantwm.c
@@ -5646,6 +5646,15 @@ updatewmhints(Client *c)
 }
 
 void
+keyview(const Arg *arg) {
+	if (arg->ui == selmon->tagset[selmon->seltags]) {
+		if (selmon->pertag->curtag != selmon->pertag->prevtag)
+			lastview(NULL);
+	} else
+		view(arg);
+}
+
+void
 view(const Arg *arg)
 {
 

--- a/instantwm.h
+++ b/instantwm.h
@@ -339,6 +339,7 @@ void updatetitle(Client *c);
 void updatewindowtype(Client *c);
 void updatewmhints(Client *c);
 void view(const Arg *arg);
+void keyview(const Arg *arg);
 void warp(const Client *c);
 void forcewarp(const Client *c);
 void warpinto(const Client *c);


### PR DESCRIPTION
using a new function because view is used in other places, which leads to crashes if I add the check in there