### PR TITLE
use exit() when quitting instantWM

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -3490,7 +3490,7 @@ propertynotify(XEvent *e)
 void
 quit(const Arg *arg)
 {
-	running = 0;
+	exit(0);
 }
 
 // return monitor that a rectangle is on


### PR DESCRIPTION
Not sure if this is the right way to keep it consistent with instantshutdown menu WM restart option