### PR TITLE
make grid layout split vertically when there are 2 clients on a horizontal monitor

### DIFF
--- a/layouts.c
+++ b/layouts.c
@@ -147,12 +147,20 @@ grid(Monitor *m) {
 	int i, n, rows, framecount;
 	unsigned int cols;
 	Client *c;
+
+	for(n = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next))
+		n++;
+
+	if (n == 2 && m->mw > m->mh)
+	{
+		tile(m);
+		return;
+	}
+
 	if (animated && clientcount() > 5)
 		framecount = 3;
 	else
 		framecount = 6;
-	for(n = 0, c = nexttiled(m->clients); c; c = nexttiled(c->next))
-		n++;
 
 	/* grid dimensions */
 	for(rows = 0; rows <= n/2; rows++)


### PR DESCRIPTION
This might be opinionated, but on wide / ultrawide monitors it makes more sense to me.