### PR TITLE
disable animations with queue and reduce code in layouts

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -435,11 +435,24 @@ void checkanimate(Client *c, int x, int y, int w, int h, int frames, int resetpo
 // move client to position within a set amount of frames
 void animateclient(Client *c, int x, int y, int w, int h, int frames, int resetpos)
 {
-	int time;
-	int oldx, oldy;
 	int width, height;
 	width = w ? w : c->w;
 	height = h ? h : c->h;
+
+	// halve frames if enough events are queried
+	frames = frames / 1 + (XEventsQueued(dpy, QueuedAlready) < 50);
+
+	// No animation if even more events are queried
+    if (!frames || XEventsQueued(dpy, QueuedAlready) > 100) {
+        if (resetpos)
+            resize(c, c->x, c->y, width, height, 0);
+        else
+            resize(c, x, y, width, height, 1);
+        return;
+    }
+
+	int time;
+	int oldx, oldy;
 
 	// prevent oversizing when minimizing/unminimizing
 	if (width > c->mon->mw - (2 * c->bw))

--- a/instantwm.c
+++ b/instantwm.c
@@ -440,7 +440,7 @@ void animateclient(Client *c, int x, int y, int w, int h, int frames, int resetp
 	height = h ? h : c->h;
 
 	// halve frames if enough events are queried
-	frames = frames / 1 + (XEventsQueued(dpy, QueuedAlready) < 50);
+	frames = frames / 1 + (XEventsQueued(dpy, QueuedAlready) > 50);
 
 	// No animation if even more events are queried
     if (!frames || XEventsQueued(dpy, QueuedAlready) > 100) {

--- a/layouts.c
+++ b/layouts.c
@@ -197,12 +197,7 @@ monocle(Monitor *m)
 	if (n > 0) /* override layout symbol */
 		snprintf(m->ltsymbol, sizeof m->ltsymbol, "[%1u]", n);
 	for (c = nexttiled(m->clients); c; c = nexttiled(c->next)) {
-		if (animated && c == selmon->sel) {
-			animateclient(c, m->wx, m->wy, m->ww - 2 * c->bw, m->wh - 2 * c->bw, 7, 0);
-			continue;
-		}
-			
-		resize(c, m->wx, m->wy, m->ww - 2 * c->bw, m->wh - 2 * c->bw, 0);
+		animateclient(c, m->wx, m->wy, m->ww - 2 * c->bw, m->wh - 2 * c->bw, 7 * (animated && c == selmon->sel), 0);
 	}
 
 }
@@ -347,7 +342,7 @@ tcl(Monitor * m)
 void
 tile(Monitor *m)
 {
-	unsigned int i, n, h, mw, my, ty, framecount, tmpanim;
+	unsigned int i, n, h, mw, my, ty, framecount;
 	Client *c;
 
 	if (animated && clientcount() > 5)
@@ -375,10 +370,7 @@ tile(Monitor *m)
 			h = (m->wh - my) / (MIN(n, m->nmaster) - i);
 
             if (n == 2) {
-                tmpanim = animated;
-                animated = 0;
-			animateclient(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), framecount, 0);
-                animated = tmpanim;
+                animateclient(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), 0, 0);
             } else {
 			animateclient(c, m->wx, m->wy + my, mw - (2*c->bw), h - (2*c->bw), framecount, 0);
 			if (m->nmaster == 1 && n > 1) {


### PR DESCRIPTION
Added check for events queried in `animateclient` and threw in a check
to see if frame count is 0 to skip animation. This allows to reduce code
in some layouts where they check to animate.

The number of events can be changed, in fact it probbally should, I chose 50 and 100 at random as a proof of concept, and where I stole this from (https://github.com/uvera/instantWM/tree/event-spamming) chose 250 and it is lower than that