### PR TITLE
recalculate tagwidth when toggling hide empty tags

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -4919,6 +4919,7 @@ toggleshowtags(const Arg *arg)
     int showtags = selmon->showtags;
     ctrltoggle(&showtags, arg->ui);
     selmon->showtags = showtags;
+	tagwidth = gettagwidth();
 	drawbar(selmon);
 }
 


### PR DESCRIPTION
Fixes `motionnotify` calculations when empty tags are hidden