### PR TITLE
Fix minimum tiled window size bug

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -5527,12 +5527,10 @@ updatesizehints(Client *c)
 	if (size.flags & PMaxSize) {
 		c->maxw = size.max_width;
 		c->maxh = size.max_height;
-	} else
+	} else {
 		c->maxw = c->maxh = 0;
-	if (size.flags & PMinSize) {
-		c->minw = size.min_width;
-		c->minh = size.min_height;
-	} else if (size.flags & PBaseSize) {
+	}
+	if (size.flags & PBaseSize) {
 		c->minw = size.base_width;
 		c->minh = size.base_height;
 	} else


### PR DESCRIPTION
Fixes window overlapping a second monitor when the size is too small. This removes checking minimum window size. Hopefully, it doesn't break anything.

Before this fix:
monitor 1
![image](https://user-images.githubusercontent.com/46199769/117875819-e7e62d80-b2a2-11eb-807d-9dec9b2ec092.png)

monitor 2
![image](https://user-images.githubusercontent.com/46199769/117875904-01877500-b2a3-11eb-9a3c-3863d350b835.png)

