### PR TITLE
Properly fix WM bar ghosting

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -1742,7 +1742,7 @@ enternotify(XEvent *e)
 	Monitor *m;
 	XCrossingEvent *ev = &e->xcrossing;
 	int resizeexit = 0;
-	if (barleavestatus && ev->y_root >= selmon->my + bh - 3) {
+	if (barleavestatus) {
 		resetbar();
 		barleavestatus = 0;
 	}


### PR DESCRIPTION
`&& ev->y_root >= selmon->my + bh - 3` makes ghosting happen when `entering` a client which is overlapping the top bar
Signed-off-by: Dušan Uverić <dusanuveric@protonmail.com>
