### PR TITLE
preserve programs on old tags when restarting instantWM

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -2383,6 +2383,27 @@ void manage(Window w, XWindowAttributes *wa) {
     updatewindowtype(c);
     updatesizehints(c);
     updatewmhints(c);
+
+    {
+        int format;
+        unsigned long *data, n, extra;
+        Monitor *m;
+        Atom atom;
+        if (XGetWindowProperty(dpy, c->win, netatom[NetClientInfo], 0L, 2L, False, XA_CARDINAL,
+                &atom, &format, &n, &extra, (unsigned char **)&data) == Success && n == 2) {
+            c->tags = *data;
+            for (m = mons; m; m = m->next) {
+                if (m->num == *(data+1)) {
+                    c->mon = m;
+                    break;
+                }
+            }
+        }
+        if (n > 0)
+            XFree(data);
+    }
+    setclienttagprop(c);
+
     updatemotifhints(c);
 
     c->sfx = c->x;
@@ -4097,6 +4118,7 @@ void sendmon(Client *c, Monitor *m) {
     }
     attach(c);
     attachstack(c);
+    setclienttagprop(c);
     focus(NULL);
     if (!c->isfloating)
         arrange(NULL);
@@ -4444,6 +4466,7 @@ void setup(void) {
     netatom[NetWMWindowTypeDialog] =
         XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
     netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
+    netatom[NetClientInfo] = XInternAtom(dpy, "_NET_CLIENT_INFO", False);
     motifatom = XInternAtom(dpy, "_MOTIF_WM_HINTS", False);
 
     xatom[Manager] = XInternAtom(dpy, "MANAGER", False);
@@ -4514,6 +4537,7 @@ void setup(void) {
     XChangeProperty(dpy, root, netatom[NetSupported], XA_ATOM, 32,
                     PropModeReplace, (unsigned char *)netatom, NetLast);
     XDeleteProperty(dpy, root, netatom[NetClientList]);
+    XDeleteProperty(dpy, root, netatom[NetClientInfo]);
     /* select events */
     wa.cursor = cursor[CurNormal]->cursor;
     wa.event_mask = SubstructureRedirectMask | SubstructureNotifyMask |
@@ -4603,12 +4627,24 @@ int computeprefix(const Arg *arg) {
     }
 }
 
+
+void
+setclienttagprop(Client *c)
+{
+	long data[] = { (long) c->tags, (long) c->mon->num };
+	XChangeProperty(dpy, c->win, netatom[NetClientInfo], XA_CARDINAL, 32,
+			PropModeReplace, (unsigned char *) data, 2);
+}
+
 void tag(const Arg *arg) {
     int ui = computeprefix(arg);
+    Client *c;
     if (selmon->sel && ui & TAGMASK) {
         if (selmon->sel->tags == 1 << 20)
             selmon->sel->issticky = 0;
+        c = selmon->sel;
         selmon->sel->tags = ui & TAGMASK;
+        setclienttagprop(c);
         focus(NULL);
         arrange(selmon);
     }
@@ -5232,6 +5268,7 @@ void toggletag(const Arg *arg) {
     newtags = selmon->sel->tags ^ (ui & TAGMASK);
     if (newtags) {
         selmon->sel->tags = newtags;
+        setclienttagprop(selmon->sel);
         focus(NULL);
         arrange(selmon);
     }

--- a/instantwm.h
+++ b/instantwm.h
@@ -59,7 +59,7 @@ enum { CurNormal, CurResize, CurMove, CurClick, CurHor, CurVert, CurTL, CurTR, C
 enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
        NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
        NetWMFullscreen, NetActiveWindow, NetWMWindowType,
-       NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms */
+       NetWMWindowTypeDialog, NetClientList, NetClientInfo, NetLast }; /* EWMH atoms */
 enum { Manager, Xembed, XembedInfo, XLast }; /* Xembed atoms */
 enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
 enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
@@ -299,6 +299,7 @@ void sendmon(Client *c, Monitor *m);
 int gettagwidth();
 int getxtag(int ix);
 void setclientstate(Client *c, long state);
+void setclienttagprop(Client *c);
 void setfocus(Client *c);
 void setfullscreen(Client *c, int fullscreen);
 void setlayout(const Arg *arg);


### PR DESCRIPTION
Apply `preserveonrestart` patch ([https://github.com/FT-Labs/phyOS-dwm/blob/master/patches/dwm-6.3-patches/dwm-preserveonrestart-6.3.diff](https://github.com/FT-Labs/phyOS-dwm/blob/master/patches/dwm-6.3-patches/dwm-preserveonrestart-6.3.diff)).

After restarting instantWM all windows won't end up in the first tag, they will be placed in their previous tag.