### PR TITLE
Revert "Fix top bar hover states during window drag"

### DIFF
--- a/instantwm.c
+++ b/instantwm.c
@@ -2698,7 +2698,7 @@ void movemouse(const Arg *arg) {
     Time lasttime = 0;
     notfloating = 0;
     occ = 0;
-    tagx = -1;
+    tagx = 0;
     colorclient = 0;
 
     // some windows are immovable
@@ -2839,15 +2839,10 @@ void movemouse(const Arg *arg) {
                     drawbars();
                 }
             }
-            if (ev.xmotion.y_root < selmon->my + bh) {
-                if (tagx != getxtag(ev.xmotion.x_root)) {
-                    tagx = getxtag(ev.xmotion.x_root);
-                    selmon->gesture = tagx + 1;
-                    drawbar(selmon);
-                }
-            } else if (tagx != -1) {
-                tagx = -1;
-                selmon->gesture = 0;
+            if (ev.xmotion.y_root < selmon->my + bh &&
+                tagx != getxtag(ev.xmotion.x_root)) {
+                tagx = getxtag(ev.xmotion.x_root);
+                selmon->gesture = tagx + 1;
                 drawbar(selmon);
             }
 


### PR DESCRIPTION
Reverts instantOS/instantWM#137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tag bar mouse gesture recognition - tag state tracking now initializes at a neutral point and updates exclusively when the cursor moves over a different tag within the bar, removing unnecessary state resets during mouse movements outside the active region for smoother interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->