### PR TITLE
Fix strict monitor stack z-ordering

### DIFF
--- a/src/contexts.rs
+++ b/src/contexts.rs
@@ -258,13 +258,20 @@ impl<'a> WmCtx<'a> {
     /// Use this for interactive operations (move/resize drags) so later
     /// restacks do not drop the dragged floating window behind others.
     pub fn raise_interactive(&mut self, win: WindowId) {
+        let mut mid_to_restack = None;
         if let Some(mid) = self.g().clients.get(&win).map(|c| c.monitor_id) {
             if let Some(mon) = self.g_mut().monitor_mut(mid) {
                 mon.stack.retain(|&w| w != win);
                 mon.stack.push(win);
+                mid_to_restack = Some(mid);
             }
         }
-        self.backend().raise_window(win);
+
+        if let Some(mid) = mid_to_restack {
+            crate::layouts::restack(self, mid);
+        } else {
+            self.backend().raise_window(win);
+        }
     }
 
     pub fn restack(&self, wins: &[WindowId]) {

--- a/src/contexts.rs
+++ b/src/contexts.rs
@@ -271,6 +271,7 @@ impl<'a> WmCtx<'a> {
             crate::layouts::restack(self, mid);
         } else {
             self.backend().raise_window(win);
+            self.flush();
         }
     }
 

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -199,20 +199,16 @@ impl<'a> FocusBackendOps for WaylandFocusBackend<'a> {
             return;
         }
 
-        // Only explicitly restack if the focused window is tiled.
-        // Floating windows should not automatically pop to the top just
-        // from being hovered, otherwise they flicker rapidly when overlapping.
-        if core.g.clients.get(&current).is_some_and(|c| c.is_floating) {
-            return;
-        }
-
-        let mut stack = Vec::new();
-        let mut floating = Vec::new();
+        let mut tiled_stack = Vec::new();
+        let mut floating_stack = Vec::new();
         let Some(monitor) = core.g.monitor(monitor_id) else {
             return;
         };
         let selected_tags = monitor.selected_tags();
         let bar_win = monitor.bar_win;
+
+        let is_tiling = monitor.current_layout().is_tiling();
+
         for &win in &monitor.stack {
             let Some(client) = core.g.clients.get(&win) else {
                 continue;
@@ -221,17 +217,22 @@ impl<'a> FocusBackendOps for WaylandFocusBackend<'a> {
                 continue;
             }
             if client.is_floating {
-                floating.push(win);
+                floating_stack.push(win);
             } else {
-                stack.push(win);
+                tiled_stack.push(win);
             }
         }
-        if let Some(idx) = stack.iter().position(|&win| win == current) {
-            let selected = stack.remove(idx);
-            stack.push(selected);
+
+        if is_tiling {
+            if let Some(idx) = tiled_stack.iter().position(|&win| win == current) {
+                let selected = tiled_stack.remove(idx);
+                tiled_stack.push(selected);
+            }
         }
+
+        let mut stack = tiled_stack;
         stack.push(bar_win);
-        stack.extend(floating);
+        stack.extend(floating_stack);
         self.wayland.backend.restack(&stack);
     }
 }
@@ -326,8 +327,10 @@ pub(crate) fn focus_soft_x11(
 /// handlers where focus failures should not abort the operation.
 pub fn focus_soft(ctx: &mut crate::contexts::WmCtx, win: Option<WindowId>) {
     use crate::contexts::WmCtx::*;
+    let previous_sel = ctx.selected_client();
+
     match ctx {
-        X11(x11_ctx) => {
+        X11(ref mut x11_ctx) => {
             let systray = x11_ctx.systray.as_deref();
             if let Err(e) = focus_x11(
                 &mut x11_ctx.core,
@@ -339,11 +342,17 @@ pub fn focus_soft(ctx: &mut crate::contexts::WmCtx, win: Option<WindowId>) {
                 log::warn!("focus_soft X11({:?}) failed: {}", win, e);
             }
         }
-        Wayland(wayland_ctx) => {
+        Wayland(ref mut wayland_ctx) => {
             if let Err(e) = focus_wayland(&mut wayland_ctx.core, &wayland_ctx.wayland, win) {
                 log::warn!("focus_soft Wayland({:?}) failed: {}", win, e);
             }
         }
+    }
+
+    let current_sel = ctx.selected_client();
+    if previous_sel != current_sel {
+        let monitor_id = ctx.g().selected_monitor_id();
+        crate::layouts::restack(ctx, monitor_id);
     }
 }
 

--- a/src/layouts/manager.rs
+++ b/src/layouts/manager.rs
@@ -134,55 +134,35 @@ pub fn restack(ctx: &mut WmCtx<'_>, monitor_id: MonitorId) {
         return;
     }
 
-    let selected_window = match monitor.sel {
-        Some(win) => win,
-        None => return,
-    };
+    let selected_window = monitor.sel;
     let layout = monitor.current_layout();
     let is_tiling = layout.is_tiling();
-    let is_monocle = layout.is_monocle();
     let selected_tags = monitor.selected_tags();
     let bar_win = monitor.bar_win;
 
-    if !is_tiling {
-        ctx.raise(selected_window);
-        ctx.flush();
-        return;
-    }
-
     let mut tiled_stack = Vec::new();
     let mut floating_stack = Vec::new();
-    if let Some(m) = ctx.g().monitor(monitor_id) {
-        for &win in &m.stack {
-            if let Some(c) = ctx.client(win) {
-                if c.is_visible_on_tags(selected_tags) {
-                    if c.is_floating {
-                        floating_stack.push(win);
-                    } else {
-                        tiled_stack.push(win);
-                    }
+
+    for &win in &monitor.stack {
+        if let Some(c) = ctx.client(win) {
+            if c.is_visible_on_tags(selected_tags) {
+                if c.is_floating {
+                    floating_stack.push(win);
+                } else {
+                    tiled_stack.push(win);
                 }
             }
         }
     }
 
-    if let Some(idx) = floating_stack
-        .iter()
-        .position(|&win| win == selected_window)
-    {
-        let selected = floating_stack.remove(idx);
-        floating_stack.push(selected);
-    } else {
-        // In monocle every tiled client occupies the full work area, so the
-        // focused tiled client must be the last tiled element in z-order.
-        // Keeping this explicit also makes the generic tiled case easier to read.
-        if let Some(idx) = tiled_stack.iter().position(|&win| win == selected_window) {
-            let selected = tiled_stack.remove(idx);
-            tiled_stack.push(selected);
-        }
-        if is_monocle && tiled_stack.last().copied() != Some(selected_window) {
-            tiled_stack.retain(|&win| win != selected_window);
-            tiled_stack.push(selected_window);
+    // The only exception: if the currently selected window is tiled,
+    // it should be raised over all other tiling windows.
+    if let Some(sel) = selected_window {
+        if is_tiling {
+            if let Some(idx) = tiled_stack.iter().position(|&win| win == sel) {
+                let selected = tiled_stack.remove(idx);
+                tiled_stack.push(selected);
+            }
         }
     }
 


### PR DESCRIPTION
Simplified the z-order logic across the Wayland and X11 backends. The stacking order is now universally driven by `monitor.stack`. Floating windows always sit on top of tiled windows. Focus changes no longer capriciously rearrange z-order; the only exception being the focused tiled window cleanly sliding over the other tiled windows. Included updates to `raise_interactive` to enforce correct stack mutation before backend operations.

---
*PR created automatically by Jules for task [13295377905431339453](https://jules.google.com/task/13295377905431339453) started by @paperbenni*

## Summary by Sourcery

Unify window restacking behavior across layouts and backends so that monitor.stack consistently drives z-order while keeping focused tiled windows above other tiled windows.

Enhancements:
- Simplify layout restacking to always derive tiled and floating stacks from monitor.stack, with the focused tiled window optionally raised within the tiled set.
- Align Wayland focus restacking with the layout manager by separating tiled and floating stacks and appending the bar window appropriately.
- Update focus_soft to trigger a layout restack on monitor selection changes instead of relying on backend-specific z-order adjustments.
- Adjust raise_interactive to mutate the monitor stack and invoke layout restack when possible before falling back to backend-specific window raising.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional restack during interactive move/resize to ensure correct monitor stacking.
  * Prevent floating windows from being promoted during hover by keeping tiled and floating stacks separate.
  * Trigger layout restack when focus/selection changes for more consistent z-order and simplified non-tiling handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->