### PR TITLE
Fix Wayland layout shift from wl-copy dummy windows

### DIFF
--- a/src/backend/wayland/compositor/handlers.rs
+++ b/src/backend/wayland/compositor/handlers.rs
@@ -81,9 +81,25 @@ impl CompositorHandler for WaylandState {
                     state.buffer().is_some()
                 })
                 .unwrap_or(false);
+
+            let (w, h) = smithay::backend::renderer::utils::with_renderer_surface_state(surface, |state| {
+                state.surface_size().map(|s| (s.w, s.h)).unwrap_or((0, 0))
+            }).unwrap_or((0, 0));
+
             if has_buffer {
                 let toplevel = self.pending_toplevels.swap_remove(pos);
-                let _ = self.map_new_toplevel(toplevel);
+                let win = self.map_new_toplevel(toplevel);
+
+                // If the requested dimensions are 1x1 or 0x0, it's likely a dummy
+                // window (e.g. some clipboard tools use this to gain focus).
+                // Force it to float so it doesn't cause a layout shift.
+                if w <= 1 && h <= 1 {
+                    if let Some(g) = self.globals_mut() {
+                        if let Some(client) = g.clients.get_mut(&win) {
+                            client.is_floating = true;
+                        }
+                    }
+                }
             }
             // No else: the surface stays in pending_toplevels until it
             // either commits a buffer or is destroyed.

--- a/src/client/rules.rs
+++ b/src/client/rules.rs
@@ -32,6 +32,11 @@ pub fn apply_rules(g: &mut Globals, win: WindowId, props: &WindowProperties) {
         if !props.title.is_empty() {
             c.name = props.title.clone();
         }
+        // wl-clipboard (wl-copy) creates dummy windows just to get keyboard focus.
+        // Float them immediately so they don't cause layout shifts.
+        if props.class == "wl-clipboard" || props.title == "wl-clipboard" {
+            c.is_floating = true;
+        }
     }
 
     let special_next = g.behavior.specialnext;


### PR DESCRIPTION
The previous GTK window visibility fix caused `wl-copy` to break the layout by spawning a tiny tiled dummy window.

When an initial `send_configure` is fired, `wl-copy` (and potentially other clipboard utilities) responds by attaching a 1x1 transparent buffer to an XDG toplevel. It does this solely to gain keyboard focus. Because instantWM previously treated this as a standard tiled window, it disrupted the layout momentarily before the tool finished and exited.

This pull request resolves the problem in two ways:
1. Adds a hardcoded rule in `src/client/rules.rs` to immediately set any window with class/title `"wl-clipboard"` to floating.
2. Adds a dynamic fallback in `src/backend/wayland/compositor/handlers.rs` that checks the size of the initial committed buffer via `with_renderer_surface_state`. If the buffer dimensions are `<= 1x1`, it marks the window as floating.

Floating windows bypass the tiling arrangement algorithm, so `wl-copy` can now gain focus and work correctly without causing any layout flicker.

---
*PR created automatically by Jules for task [757461423317328864](https://jules.google.com/task/757461423317328864) started by @paperbenni*

## Summary by Sourcery

Prevent tiny Wayland clipboard helper windows from disrupting tiling layouts by treating them as floating.

Bug Fixes:
- Avoid layout shifts caused by wl-clipboard (wl-copy) dummy windows being tiled as normal toplevels.

Enhancements:
- Automatically float new toplevels whose initial committed buffer is 1x1 or smaller to avoid transient dummy windows affecting the layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Minimal-sized windows are now automatically treated as floating to improve workspace organization and prevent layout disruption.
  * Clipboard utility windows are now treated as floating by default for better usability and seamless clipboard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->