### PR TITLE
Maintain focus history per tag

### DIFF
--- a/src/focus.rs
+++ b/src/focus.rs
@@ -43,7 +43,19 @@ fn resolve_focus_target(core: &CoreCtx, win: Option<WindowId>) -> Option<FocusTa
     });
 
     if target.is_none() {
-        target = mon.first_visible_client(core.globals().clients.map());
+        // Try focus history first
+        if let Some(&hist_win) = mon.tag_focus_history.get(&selected.bits()) {
+            if core.globals().clients.get(&hist_win).map_or(false, |c| {
+                c.is_visible_on_tags(selected.bits()) && !c.is_hidden
+            }) {
+                target = Some(hist_win);
+            }
+        }
+
+        // Fallback to top of stack
+        if target.is_none() {
+            target = mon.first_visible_client(core.globals().clients.map());
+        }
     }
 
     Some(FocusTargetResult {
@@ -66,6 +78,9 @@ fn update_focus_state(core: &mut CoreCtx, result: FocusTargetResult) -> (Option<
 
     if let Some(mon) = core.globals_mut().monitor_mut(sel_mon_id) {
         mon.sel = target;
+        if let Some(t) = target {
+            mon.tag_focus_history.insert(mon.selected_tags(), t);
+        }
     }
 
     (target, selection_state_changed)

--- a/src/types/monitor.rs
+++ b/src/types/monitor.rs
@@ -74,6 +74,8 @@ pub struct Monitor {
     pub clients: Vec<WindowId>,
     /// Currently selected client.
     pub sel: Option<WindowId>,
+    /// Focus history per tag mask.
+    pub tag_focus_history: HashMap<u32, WindowId>,
     /// Overlay window.
     pub overlay: Option<WindowId>,
     /// Stack list (stacking order).
@@ -112,6 +114,7 @@ impl Default for Monitor {
             tags: Vec::new(),
             clients: Vec::new(),
             sel: None,
+            tag_focus_history: HashMap::new(),
             overlay: None,
             stack: Vec::new(),
             fullscreen: None,


### PR DESCRIPTION
Fixes an issue where switching back to a tag would always select the window at the top of the stack, rather than the window that was previously active when the user left the tag.

- Added `tag_focus_history: HashMap<u32, WindowId>` to `Monitor`.
- Updated `update_focus_state` to store the newly focused window into the active tag mask's history.
- Modified `resolve_focus_target` to consult `tag_focus_history` before using `first_visible_client` as a fallback.

---
*PR created automatically by Jules for task [1143635075217860583](https://jules.google.com/task/1143635075217860583) started by @paperbenni*

## Summary by Sourcery

Maintain per-tag focus history so returning to a tag restores the previously focused window instead of always selecting the top of the stack.

Bug Fixes:
- Fix incorrect focus behavior when switching back to a tag by restoring the window that was last active on that tag instead of the top-of-stack window.

Enhancements:
- Track focus history per tag on each monitor and consult it when resolving focus, falling back to the top-of-stack window only when no valid history exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window managers now track and restore the previously focused window for each tag, providing seamless navigation when switching between workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->