### PR TITLE
Fix high idle CPU usage in Wayland backends

### DIFF
--- a/src/wayland/runtime/drm.rs
+++ b/src/wayland/runtime/drm.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 use std::process::exit;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use smithay::backend::drm::{DrmDevice, DrmEvent};
 use smithay::backend::libinput::LibinputInputBackend;
@@ -292,7 +291,7 @@ fn run_event_loop(
     let pointer_handle = state.pointer.clone();
 
     event_loop
-        .run(Duration::from_millis(16), state, move |state| {
+        .run(None, state, move |state| {
             process_completed_crtcs(state, shared, output_surfaces);
 
             process_pending_libinput_events(state, shared);

--- a/src/wayland/runtime/winit.rs
+++ b/src/wayland/runtime/winit.rs
@@ -4,7 +4,6 @@
 //! Wayland or X11 session.
 
 use std::process::exit;
-use std::time::Duration;
 
 use smithay::backend::input::InputEvent;
 use smithay::backend::renderer::ImportDma;
@@ -87,7 +86,7 @@ pub fn run() -> ! {
 
     let loop_signal: LoopSignal = event_loop.get_signal();
     event_loop
-        .run(Duration::from_millis(16), &mut state, move |mut state| {
+        .run(None, &mut state, move |mut state| {
             winit_loop.dispatch_new_events(|event| match event {
                 WinitEvent::Resized { size, .. } => {
                     crate::wayland::input::handle_resize(&mut state.wm, &output, size.w, size.h);


### PR DESCRIPTION
Resolves an issue where instantWM was consuming ~9% idle CPU on the Wayland backend due to a 16ms timeout in `calloop::EventLoop::run()`. Removing the timeout allows the event loop to block correctly.

---
*PR created automatically by Jules for task [3785322044631998059](https://jules.google.com/task/3785322044631998059) started by @paperbenni*

## Summary by Sourcery

Bug Fixes:
- Eliminate high idle CPU usage in Wayland DRM and winit backends by allowing their event loops to block instead of waking every 16ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated event loop scheduling in Wayland runtime to run without fixed timeout intervals, replacing the previous 60Hz tick rate. This alters how the system processes window events and rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->